### PR TITLE
[BUGFIX] Ensure the legacy script loads correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - '6'
 
 sudo: false
 dist: trusty
@@ -33,8 +33,8 @@ jobs:
   include:
     # runs linting and tests with current locked deps
 
-    - stage: "Tests"
-      name: "Tests"
+    - stage: 'Tests'
+      name: 'Tests'
       install:
         - yarn install --non-interactive
       script:
@@ -42,17 +42,18 @@ jobs:
         - yarn lint:js
         - yarn test
 
-    - name: "Floating Dependencies"
+    - name: 'Floating Dependencies'
       script:
         - yarn test
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
+    - stage: 'Additional Tests'
       env: EMBER_TRY_SCENARIO=ember-lts-2.16
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-release
+    - env: EMBER_TRY_SCENARIO=ember-release TEST_FORCE_INCLUDE_LEGACY_SCRIPT=true
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery

--- a/index.js
+++ b/index.js
@@ -29,20 +29,27 @@ module.exports = {
     let parentOptions = (parent.options || {})['ember-cli-babel-polyfills'];
     let hostOptions = (host.options || {})['ember-cli-babel-polyfills'];
 
-    this._options = Object.assign({}, DEFAULT_OPTIONS, parentOptions, hostOptions);
+    this._options = Object.assign(
+      {},
+      DEFAULT_OPTIONS,
+      parentOptions,
+      hostOptions
+    );
 
-    this._isBabel7 = new VersionChecker(this.project).for('ember-cli-babel').gte('7.0.0');
+    this._isBabel7 = new VersionChecker(this.project)
+      .for('ember-cli-babel')
+      .gte('7.0.0');
 
     this.import('vendor/ember-cli-babel-polyfills/shared.js', {
-      outputFile: 'assets/polyfill-shared.js'
+      outputFile: 'assets/polyfill-shared.js',
     });
 
     this.import('vendor/ember-cli-babel-polyfills/legacy.js', {
-      outputFile: 'assets/polyfill-legacy.js'
+      outputFile: 'assets/polyfill-legacy.js',
     });
 
     this.import('vendor/ember-cli-babel-polyfills/evergreen.js', {
-      outputFile: 'assets/polyfill-evergreen.js'
+      outputFile: 'assets/polyfill-evergreen.js',
     });
   },
 
@@ -55,7 +62,7 @@ module.exports = {
     let TransformAmd = require('./lib/transform-amd');
 
     let legacyTargets = this._options.legacyTargets || this.project.targets;
-    let evergreenTargets = this._options.evergreenTargets
+    let evergreenTargets = this._options.evergreenTargets;
 
     let entries = new MergeTrees([
       writeFile('legacy.js', this._getEntryForTargets(legacyTargets)),
@@ -70,10 +77,7 @@ module.exports = {
           dir: 'output',
           format: 'amd',
         },
-        plugins: [
-          resolve(),
-          commonjs(),
-        ],
+        plugins: [resolve(), commonjs()],
       },
     });
 
@@ -81,23 +85,27 @@ module.exports = {
       srcDir: 'output',
       destDir: 'ember-cli-babel-polyfills',
       getDestinationPath(path) {
-        return (path !== 'legacy.js' && path !== 'evergreen.js') ? 'shared.js' : path;
+        return path !== 'legacy.js' && path !== 'evergreen.js'
+          ? 'shared.js'
+          : path;
       },
     });
   },
 
   _getEntryForTargets(targets) {
     let babel = require(this._isBabel7 ? '@babel/core' : 'babel-core');
-    let presetEnvPath = require.resolve(this._isBabel7 ? '@babel/preset-env' : 'babel-preset-env');
+    let presetEnvPath = require.resolve(
+      this._isBabel7 ? '@babel/preset-env' : 'babel-preset-env'
+    );
 
-    return babel.transform(
-      'import "@babel/polyfill";',
-      {
-        presets: [
-          [presetEnvPath, { targets: this._getTargets(targets), useBuiltIns: 'entry' }],
+    return babel.transform('import "@babel/polyfill";', {
+      presets: [
+        [
+          presetEnvPath,
+          { targets: this._getTargets(targets), useBuiltIns: 'entry' },
         ],
-      }
-    ).code;
+      ],
+    }).code;
   },
 
   _getTargets(targets) {
@@ -115,10 +123,12 @@ module.exports = {
   },
 
   contentFor(type, { rootURL }) {
+    let forceInclude = process.env.TEST_FORCE_INCLUDE_LEGACY_SCRIPT
+
     if (this._options.includeScriptTags && type === 'body') {
       return `
         <script src="${rootURL}assets/polyfill-shared.js"></script>
-        <script src="${rootURL}assets/polyfill-legacy.js" nomodule></script>
+        <script src="${rootURL}assets/polyfill-legacy.js" ${forceInclude ? '' : 'nomodule'}></script>
         <script src="${rootURL}assets/polyfill-evergreen.js"></script>
       `;
     }

--- a/lib/transform-amd.js
+++ b/lib/transform-amd.js
@@ -10,7 +10,7 @@ function __babelPolyfillDefine(name, requires, module) {
 		return require === 'exports' ? exports : BABEL_POLYFILL_MODULES[require];
 	});
 
-	module(resolved);
+  module.apply(null, resolved);
 	BABEL_POLYFILL_MODULES[name] = exports;
 }
 `;
@@ -26,9 +26,12 @@ module.exports = class TransformAmd extends Filter {
       );
     }
 
-    return preamble + contents.replace(
-      /define\(\['[.\w/\\]*?'\],/,
-      `__babelPolyfillDefine('shared.js', ['exports'],`
+    return (
+      preamble +
+      contents.replace(
+        /define\(\['[.\w/\\]*?'\],/,
+        `__babelPolyfillDefine('shared.js', ['exports'],`
+      )
     );
   }
-}
+};

--- a/tests/unit/basic-test.js
+++ b/tests/unit/basic-test.js
@@ -1,6 +1,12 @@
 import { module, test } from 'qunit';
 
-import { isIE, isEdge, isChrome, isFirefox, isSafari } from '../helpers/browser-detection';
+import {
+  isIE,
+  isEdge,
+  isChrome,
+  isFirefox,
+  isSafari,
+} from '../helpers/browser-detection';
 
 module('polyfill', function() {
   if (isIE) {
@@ -9,10 +15,10 @@ module('polyfill', function() {
         // we will load all modules in legacy, but the evergreen module is
         // mostly/fully empty
         assert.ok(
-          window.BABEL_POLYFILL_MODULES !== undefined
-          && window.BABEL_POLYFILL_MODULES['shared.js'] !== undefined
-          && window.BABEL_POLYFILL_MODULES['legacy.js'] !== undefined
-          && window.BABEL_POLYFILL_MODULES['evergreen.js'] !== undefined,
+          window.BABEL_POLYFILL_MODULES !== undefined &&
+            window.BABEL_POLYFILL_MODULES['shared.js'] !== undefined &&
+            window.BABEL_POLYFILL_MODULES['legacy.js'] !== undefined &&
+            window.BABEL_POLYFILL_MODULES['evergreen.js'] !== undefined,
           'polyfill was loaded'
         );
       });
@@ -23,19 +29,39 @@ module('polyfill', function() {
     });
   } else {
     module('evergreen', function() {
-      test('it loads', function(assert) {
-        assert.ok(
-          window.BABEL_POLYFILL_MODULES !== undefined
-          && window.BABEL_POLYFILL_MODULES['shared.js'] !== undefined
-          && window.BABEL_POLYFILL_MODULES['evergreen.js'] !== undefined,
-          'polyfill was loaded'
-        );
+      let HAS_LEGACY_SCRIPT = !Array.from(
+        document.querySelectorAll('script')
+      ).find(
+        script => script.attributes.src.value === '/assets/polyfill-legacy.js'
+      ).attributes.nomodule;
 
-        assert.ok(
-          window.BABEL_POLYFILL_MODULES['legacy.js'] === undefined,
-          'legacy polyfill was not loaded'
-        );
-      });
+      if (HAS_LEGACY_SCRIPT) {
+        test('it loads', function(assert) {
+          // we will load all modules in legacy, but the evergreen module is
+          // mostly/fully empty
+          assert.ok(
+            window.BABEL_POLYFILL_MODULES !== undefined &&
+              window.BABEL_POLYFILL_MODULES['shared.js'] !== undefined &&
+              window.BABEL_POLYFILL_MODULES['legacy.js'] !== undefined &&
+              window.BABEL_POLYFILL_MODULES['evergreen.js'] !== undefined,
+            'polyfill was loaded'
+          );
+        });
+      } else {
+        test('it loads', function(assert) {
+          assert.ok(
+            window.BABEL_POLYFILL_MODULES !== undefined &&
+              window.BABEL_POLYFILL_MODULES['shared.js'] !== undefined &&
+              window.BABEL_POLYFILL_MODULES['evergreen.js'] !== undefined,
+            'polyfill was loaded'
+          );
+
+          assert.ok(
+            window.BABEL_POLYFILL_MODULES['legacy.js'] === undefined,
+            'legacy polyfill was not loaded'
+          );
+        });
+      }
 
       if (isChrome || isFirefox || isSafari) {
         test('it works', function(assert) {
@@ -45,7 +71,10 @@ module('polyfill', function() {
           // polyfill in other browsers despite being non-standard. We should add a lint
           // rule preventing people from using, but seems like a good signal the the
           // polyfill was included correctly for now.
-          assert.ok(typeof window.setImmediate === 'function', 'setImmediate exists');
+          assert.ok(
+            typeof window.setImmediate === 'function',
+            'setImmediate exists'
+          );
         });
       }
 
@@ -53,9 +82,12 @@ module('polyfill', function() {
         test('it works', function(assert) {
           // This test will eventually stop working once dom iterable is
           // available in Edge.
-          assert.ok(document.forms[Symbol.iterator], 'DOM Iterables are iterable');
+          assert.ok(
+            document.forms[Symbol.iterator],
+            'DOM Iterables are iterable'
+          );
         });
       }
     });
   }
-})
+});


### PR DESCRIPTION
The AMD module shim was incorrect, causing the legacy IE script not to
load. This failed even in Chrome, but we didn't see the failure since
the script was never loaded and we haven't set up cross browser testing
yet. This PR fixes the issue and adds tests that ensure the legacy
polyfill loads correctly in Chrome at least.